### PR TITLE
recalculate avg duration wholistically

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -181,7 +181,13 @@ export default async function DashboardPage() {
                         {accountCount} account{accountCount === 1 ? "" : "s"}
                       </span>
                       {goal.targetDate && <span>target {goal.targetDate}</span>}
-                      {duration != null && <span>avg bond dur. {duration.toFixed(2)} yr</span>}
+                      {duration != null && (
+                        <span
+                          title="Weighted average duration across all holdings — bonds at their duration, cash and equity counted as 0 years"
+                        >
+                          avg duration {duration.toFixed(2)} yr
+                        </span>
+                      )}
                     </div>
                   </div>
                   <div className="text-right">

--- a/src/lib/allocation.ts
+++ b/src/lib/allocation.ts
@@ -122,9 +122,10 @@ export function resolveActiveTargets(
 }
 
 /**
- * Weighted average bond duration across a goal's holdings.
- * Uses asset.avgDurationYears directly (falls back to 0 for equities/cash).
- * Weight = holding value. Returns years or null if no bond exposure.
+ * Weighted average duration across all of a goal's holdings.
+ * Bonds use their avgDurationYears; cash and equity count as 0.
+ * Weight = holding value. Returns null when no bond exposure exists
+ * (so the stat is hidden for equity-only or cash-only portfolios).
  */
 export function computeWeightedBondDuration(
   holdings: HoldingRow[],
@@ -132,15 +133,18 @@ export function computeWeightedBondDuration(
 ): number | null {
   const byId = new Map(assets.map((a) => [a.id, a.avgDurationYears] as const));
   let weightedSum = 0;
-  let totalWeight = 0;
+  let totalValue = 0;
+  let hasBonds = false;
   for (const h of holdings) {
+    const v = Number(h.value);
+    if (!Number.isFinite(v) || v <= 0) continue;
+    totalValue += v;
     const dur = byId.get(h.assetId);
     if (dur == null) continue;
     const d = Number(dur);
-    const v = Number(h.value);
-    if (!Number.isFinite(d) || !Number.isFinite(v) || d === 0) continue;
+    if (!Number.isFinite(d) || d === 0) continue;
     weightedSum += d * v;
-    totalWeight += v;
+    hasBonds = true;
   }
-  return totalWeight === 0 ? null : weightedSum / totalWeight;
+  return hasBonds && totalValue > 0 ? weightedSum / totalValue : null;
 }


### PR DESCRIPTION
When looking at the dashboard portfolio item, just seeing the average duration of the fixed-income sleeve is a little misleading in terms of total interest-rate risk.

By adding in the values of cash and equities to the denominator, but counting their durations as 0, we are capturing their effect on the portfolio. This is an industry standard technique for portfolio analysis.

Closes issue #8