### PR TITLE
fix: redirect to list after deleting account or goal

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "shadcn": {
       "command": "npx",
-      "args": [
-        "shadcn@latest",
-        "mcp"
-      ]
+      "args": ["shadcn@latest", "mcp"]
     }
   }
 }

--- a/src/app/accounts/[accountId]/page.tsx
+++ b/src/app/accounts/[accountId]/page.tsx
@@ -6,7 +6,7 @@ import { listAssetsForUser } from "@allocado/db/queries/assets";
 import { listGoals } from "@allocado/db/queries/goals";
 import { listHoldingsForAccount } from "@allocado/db/queries/holdings";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { HoldingsEditor } from "./HoldingsEditor";
 
 const ACCOUNT_TYPES = [
@@ -145,7 +145,8 @@ export default async function AccountDetailPage({
         <form
           action={async () => {
             "use server";
-            await deleteAccount(accountId);
+            const res = await deleteAccount(accountId);
+            if (res.ok) redirect("/accounts");
           }}
         >
           <DestructiveButton type="submit">Delete account (and all its holdings)</DestructiveButton>

--- a/src/app/goals/[goalId]/page.tsx
+++ b/src/app/goals/[goalId]/page.tsx
@@ -6,7 +6,7 @@ import { listAssetClassesForUser } from "@allocado/db/queries/assets";
 import { getGoal } from "@allocado/db/queries/goals";
 import { listTargetsForGoal } from "@allocado/db/queries/targets";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { TargetsEditor } from "./TargetsEditor";
 
 export default async function GoalDetailPage({ params }: { params: Promise<{ goalId: string }> }) {
@@ -163,7 +163,8 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ goa
         <form
           action={async () => {
             "use server";
-            await deleteGoal(goalId);
+            const res = await deleteGoal(goalId);
+            if (res.ok) redirect("/goals");
           }}
         >
           <DestructiveButton type="submit">Delete goal</DestructiveButton>


### PR DESCRIPTION
## Summary

- Deleting an account or goal was leaving the user on the now-deleted detail page, which re-rendered and hit `notFound()` — surfacing as a 404
- Added `redirect("/accounts")` and `redirect("/goals")` after successful deletion, matching the existing pattern used by the asset delete handler

Closes KB-13

## Test plan

- [ ] Delete an account — confirm redirect to `/accounts`
- [ ] Delete a goal — confirm redirect to `/goals`
- [ ] Confirm the deleted item no longer appears in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)