### PR TITLE
[KB-9] Add drag-to-reorder for accounts

### DIFF
--- a/drizzle/0003_fresh_redwing.sql
+++ b/drizzle/0003_fresh_redwing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "accounts" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,594 @@
+{
+  "id": "082cedd3-9c1d-44b9-bb66-265aa5511758",
+  "prevId": "2aa529f8-0699-4567-86a7-9ca8bc85dc82",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_goal_id_idx": {
+          "name": "accounts_goal_id_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_goal_id_goals_id_fk": {
+          "name": "accounts_goal_id_goals_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "goals",
+          "columnsFrom": ["goal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allocation_targets": {
+      "name": "allocation_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_class_id": {
+          "name": "asset_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_pct": {
+          "name": "target_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allocation_targets_goal_id_goals_id_fk": {
+          "name": "allocation_targets_goal_id_goals_id_fk",
+          "tableFrom": "allocation_targets",
+          "tableTo": "goals",
+          "columnsFrom": ["goal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "allocation_targets_asset_class_id_asset_classes_id_fk": {
+          "name": "allocation_targets_asset_class_id_asset_classes_id_fk",
+          "tableFrom": "allocation_targets",
+          "tableTo": "asset_classes",
+          "columnsFrom": ["asset_class_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "targets_goal_class_date_unique": {
+          "name": "targets_goal_class_date_unique",
+          "nullsNotDistinct": true,
+          "columns": ["goal_id", "asset_class_id", "effective_date"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "targets_pct_range": {
+          "name": "targets_pct_range",
+          "value": "\"allocation_targets\".\"target_pct\" >= 0 AND \"allocation_targets\".\"target_pct\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.asset_class_allocations": {
+      "name": "asset_class_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_class_id": {
+          "name": "asset_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratio": {
+          "name": "ratio",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_class_allocations_asset_id_assets_id_fk": {
+          "name": "asset_class_allocations_asset_id_assets_id_fk",
+          "tableFrom": "asset_class_allocations",
+          "tableTo": "assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_class_allocations_asset_class_id_asset_classes_id_fk": {
+          "name": "asset_class_allocations_asset_class_id_asset_classes_id_fk",
+          "tableFrom": "asset_class_allocations",
+          "tableTo": "asset_classes",
+          "columnsFrom": ["asset_class_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aca_asset_class_unique": {
+          "name": "aca_asset_class_unique",
+          "nullsNotDistinct": false,
+          "columns": ["asset_id", "asset_class_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "aca_ratio_range": {
+          "name": "aca_ratio_range",
+          "value": "\"asset_class_allocations\".\"ratio\" >= 0 AND \"asset_class_allocations\".\"ratio\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.asset_classes": {
+      "name": "asset_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_class_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_duration_years": {
+          "name": "avg_duration_years",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_classes_user_name_unique": {
+          "name": "asset_classes_user_name_unique",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_updated_at": {
+          "name": "price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_duration_years": {
+          "name": "avg_duration_years",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_user_ticker_unique": {
+          "name": "assets_user_ticker_unique",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "ticker"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holdings": {
+      "name": "holdings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holdings_account_id_accounts_id_fk": {
+          "name": "holdings_account_id_accounts_id_fk",
+          "tableFrom": "holdings",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "holdings_asset_id_assets_id_fk": {
+          "name": "holdings_asset_id_assets_id_fk",
+          "tableFrom": "holdings",
+          "tableTo": "assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "holdings_account_asset_unique": {
+          "name": "holdings_account_asset_unique",
+          "nullsNotDistinct": false,
+          "columns": ["account_id", "asset_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": ["taxable", "ira", "roth_ira", "401k", "hsa", "other"]
+    },
+    "public.asset_class_type": {
+      "name": "asset_class_type",
+      "schema": "public",
+      "values": ["stock", "bond", "cash", "other"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777002745066,
       "tag": "0002_tiresome_phalanx",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781796841476,
+      "tag": "0003_fresh_redwing",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/_actions/accounts.ts
+++ b/src/app/_actions/accounts.ts
@@ -2,6 +2,7 @@
 
 import { db } from "@allocado/db";
 import { requireUserId } from "@allocado/db/auth";
+import { maxAccountSortOrder } from "@allocado/db/queries/accounts";
 import { accounts, goals } from "@allocado/db/schema";
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
@@ -31,9 +32,11 @@ export async function createAccount(formData: FormData): Promise<ActionResult<{ 
       .limit(1);
     if (!goal[0]) return { ok: false, error: "Goal not found" };
 
+    const sortOrder = (await maxAccountSortOrder(userId)) + 1;
+
     const [row] = await db
       .insert(accounts)
-      .values({ userId, goalId, name, institution, accountType, notes })
+      .values({ userId, goalId, name, institution, accountType, notes, sortOrder })
       .returning({ id: accounts.id });
 
     revalidatePath("/accounts");
@@ -75,6 +78,25 @@ export async function deleteAccount(accountId: string): Promise<ActionResult> {
   try {
     const userId = await requireUserId();
     await db.delete(accounts).where(and(eq(accounts.userId, userId), eq(accounts.id, accountId)));
+    revalidatePath("/accounts");
+    revalidatePath("/dashboard");
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+export async function reorderAccounts(orderedIds: string[]): Promise<ActionResult> {
+  try {
+    const userId = await requireUserId();
+    await db.transaction(async (tx) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await tx
+          .update(accounts)
+          .set({ sortOrder: i })
+          .where(and(eq(accounts.id, orderedIds[i]), eq(accounts.userId, userId)));
+      }
+    });
     revalidatePath("/accounts");
     revalidatePath("/dashboard");
     return { ok: true };

--- a/src/app/accounts/AccountsList.tsx
+++ b/src/app/accounts/AccountsList.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { reorderAccounts } from "@allocado/app/_actions/accounts";
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import Link from "next/link";
+import { useOptimistic, useTransition } from "react";
+
+type Account = {
+  id: string;
+  name: string;
+  institution: string | null;
+  accountType: string;
+  notes: string | null;
+  goalName: string | null;
+};
+
+export function AccountsList({ accounts }: { accounts: Account[] }) {
+  const [optimisticAccounts, setOptimisticAccounts] = useOptimistic(accounts);
+  const [, startTransition] = useTransition();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = optimisticAccounts.findIndex((a) => a.id === active.id);
+    const newIndex = optimisticAccounts.findIndex((a) => a.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = [...optimisticAccounts];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
+
+    startTransition(async () => {
+      setOptimisticAccounts(reordered);
+      await reorderAccounts(reordered.map((a) => a.id));
+    });
+  }
+
+  if (optimisticAccounts.length === 0) {
+    return <p className="text-sm text-avocado-700">No accounts yet.</p>;
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext
+        items={optimisticAccounts.map((a) => a.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <ul className="divide-y divide-avocado-100">
+          {optimisticAccounts.map((a) => (
+            <SortableAccountRow key={a.id} account={a} />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SortableAccountRow({ account }: { account: Account }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: account.id });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={`flex items-center gap-3 py-3 ${isDragging ? "opacity-50" : ""}`}
+    >
+      <button
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        type="button"
+        className="cursor-grab touch-none text-avocado-300 hover:text-avocado-600 active:cursor-grabbing"
+        aria-label="Drag to reorder"
+      >
+        <GripIcon />
+      </button>
+
+      <div className="flex-1">
+        <Link
+          href={`/accounts/${account.id}`}
+          className="font-medium text-avocado-900 hover:underline"
+        >
+          {account.name}
+        </Link>
+        <span className="ml-3 text-xs text-avocado-600">{account.accountType}</span>
+        {account.institution && (
+          <span className="ml-2 text-xs text-avocado-600">· {account.institution}</span>
+        )}
+        <p className="mt-1 text-xs text-avocado-600">Goal: {account.goalName ?? "(none)"}</p>
+      </div>
+
+      <Link
+        href={`/accounts/${account.id}`}
+        className="text-sm font-medium text-avocado-700 hover:text-avocado-900"
+      >
+        Holdings →
+      </Link>
+    </li>
+  );
+}
+
+function GripIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <circle cx="5" cy="4" r="1.5" />
+      <circle cx="11" cy="4" r="1.5" />
+      <circle cx="5" cy="8" r="1.5" />
+      <circle cx="11" cy="8" r="1.5" />
+      <circle cx="5" cy="12" r="1.5" />
+      <circle cx="11" cy="12" r="1.5" />
+    </svg>
+  );
+}

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -3,6 +3,7 @@ import { requireUserId } from "@allocado/db/auth";
 import { listAccounts } from "@allocado/db/queries/accounts";
 import { listGoals } from "@allocado/db/queries/goals";
 import Link from "next/link";
+import { AccountsList } from "./AccountsList";
 
 const ACCOUNT_TYPES = [
   { value: "taxable", label: "Taxable brokerage" },
@@ -28,35 +29,7 @@ export default async function AccountsPage() {
 
       <section className="card flex flex-col gap-4">
         <h2 className="text-lg font-medium text-avocado-800">Your accounts</h2>
-        {accounts.length === 0 ? (
-          <p className="text-sm text-avocado-700">No accounts yet.</p>
-        ) : (
-          <ul className="divide-y divide-avocado-100">
-            {accounts.map((a) => (
-              <li key={a.id} className="flex items-center justify-between py-3">
-                <div>
-                  <Link
-                    href={`/accounts/${a.id}`}
-                    className="font-medium text-avocado-900 hover:underline"
-                  >
-                    {a.name}
-                  </Link>
-                  <span className="ml-3 text-xs text-avocado-600">{a.accountType}</span>
-                  {a.institution && (
-                    <span className="ml-2 text-xs text-avocado-600">· {a.institution}</span>
-                  )}
-                  <p className="mt-1 text-xs text-avocado-600">Goal: {a.goalName ?? "(none)"}</p>
-                </div>
-                <Link
-                  href={`/accounts/${a.id}`}
-                  className="text-sm font-medium text-avocado-700 hover:text-avocado-900"
-                >
-                  Holdings →
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
+        <AccountsList accounts={accounts} />
       </section>
 
       <section className="card flex flex-col gap-4">

--- a/src/db/queries/accounts.ts
+++ b/src/db/queries/accounts.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, max } from "drizzle-orm";
 import { db } from "../index";
 import { accounts, goals } from "../schema";
 
@@ -17,7 +17,7 @@ export async function listAccounts(userId: string) {
     .from(accounts)
     .leftJoin(goals, eq(accounts.goalId, goals.id))
     .where(eq(accounts.userId, userId))
-    .orderBy(asc(accounts.createdAt));
+    .orderBy(asc(accounts.sortOrder), asc(accounts.createdAt));
 }
 
 export async function listAccountsForGoal(userId: string, goalId: string) {
@@ -25,7 +25,15 @@ export async function listAccountsForGoal(userId: string, goalId: string) {
     .select()
     .from(accounts)
     .where(and(eq(accounts.userId, userId), eq(accounts.goalId, goalId)))
-    .orderBy(asc(accounts.createdAt));
+    .orderBy(asc(accounts.sortOrder), asc(accounts.createdAt));
+}
+
+export async function maxAccountSortOrder(userId: string): Promise<number> {
+  const [{ val }] = await db
+    .select({ val: max(accounts.sortOrder) })
+    .from(accounts)
+    .where(eq(accounts.userId, userId));
+  return val ?? -1;
 }
 
 export async function getAccount(userId: string, accountId: string) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -50,6 +50,7 @@ export const accounts = pgTable(
     institution: text("institution"),
     accountType: accountTypeEnum("account_type").notNull(),
     notes: text("notes"),
+    sortOrder: integer("sort_order").default(0).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (t) => [index("accounts_user_id_idx").on(t.userId), index("accounts_goal_id_idx").on(t.goalId)],


### PR DESCRIPTION
## What

- Adds `sort_order` column to the `accounts` table (migration `0003_fresh_redwing.sql`)
- New `AccountsList.tsx` client component with dnd-kit drag handles, mirroring the goals list
- `createAccount` now appends new accounts at the end; `reorderAccounts` server action persists the new order

## Why

Users need to control the display order of their accounts on the Accounts page, matching the sort/reorder functionality already available for goals.

## Testing

### Prerequisites
- Must be signed in with at least two accounts created

### Steps
1. Open the app and navigate to **/accounts**
2. Confirm each account row has a grip icon (⠿) on the left — expect: drag handle visible
3. Drag an account row to a new position and release — expect: list reorders immediately (optimistic UI), order persists after page refresh
4. Create a new account — expect: it appears at the bottom of the list
5. Confirm account name, type, institution, and goal label still display correctly on each row
6. Navigate to **/goals** — expect: goal reordering still works, no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)