### PR TITLE
Fix prod sync failure on multi-lot positions (KB-27)

### DIFF
--- a/src/app/_actions/plaid.ts
+++ b/src/app/_actions/plaid.ts
@@ -448,7 +448,10 @@ async function syncItemInternal(userId: string, itemId: string): Promise<void> {
   for (const [plaidAccountId, accountRowId] of accountRowIdByPlaidId) {
     const rows = holdingList.filter((h) => h.account_id === plaidAccountId);
 
-    const snapshot: { securityRowId: string; value: string; price: string | null }[] = [];
+    // Plaid may return several records for the same security in one account
+    // (separate tax lots); aggregate them or the snapshot upsert would hit the
+    // same (account, security) key twice in one statement.
+    const bySecurity = new Map<string, { value: number; price: number | null }>();
     for (const h of rows) {
       const securityRowId = securityRowIdByPlaidId.get(h.security_id);
       if (!securityRowId) continue;
@@ -457,12 +460,19 @@ async function syncItemInternal(userId: string, itemId: string): Promise<void> {
         (h.institution_price != null ? h.quantity * h.institution_price : null);
       if (rawValue == null || !Number.isFinite(rawValue)) continue;
       const price = h.institution_price ?? closePriceBySecurityRowId.get(securityRowId) ?? null;
-      snapshot.push({
-        securityRowId,
-        value: moneyFromNumber(rawValue),
-        price: price != null ? moneyFromNumber(price) : null,
-      });
+      const prev = bySecurity.get(securityRowId);
+      if (prev) {
+        prev.value += rawValue;
+        if (prev.price == null) prev.price = price;
+      } else {
+        bySecurity.set(securityRowId, { value: rawValue, price });
+      }
     }
+    const snapshot = [...bySecurity.entries()].map(([securityRowId, v]) => ({
+      securityRowId,
+      value: moneyFromNumber(v.value),
+      price: v.price != null ? moneyFromNumber(v.price) : null,
+    }));
 
     const [linkRow] = await db
       .select({ accountId: plaidAccounts.accountId })


### PR DESCRIPTION
## Summary

Follow-up to #20. Syncing against a real institution failed with:

```text
ON CONFLICT DO UPDATE command cannot affect row a second time
```

Real brokerages can return several holding records for the same security in one account (separate tax lots / cost-basis records) — sandbox data never does. Those lots became duplicate (plaid_account, security) rows inside a single snapshot `INSERT … ON CONFLICT`, which Postgres rejects.

## Fix

Aggregate lots per security before the snapshot upsert: values are summed, and the first available institution price is kept. One row per (plaid_account, security) is guaranteed regardless of how many lots Plaid reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)